### PR TITLE
Update course with June 3, 2025 AI developments and market changes

### DIFF
--- a/Lecture 1- Introduction to AI and Current Developments.md
+++ b/Lecture 1- Introduction to AI and Current Developments.md
@@ -101,9 +101,9 @@ ChatGPT is now multimodal—it can analyze images, documents, and soon, videos. 
 ##### [seq:040] Anthropic (Claude)
 
 ###### SCRIPT
- "Claude is developed by Anthropic—a company focused heavily on ethical AI. Claude 2 was known for being more verbose and cautious, while Claude 3 showed competitive reasoning skills. Claude 4, released in May 2025, presents an interesting case: while benchmark results are mixed, it truly excels in 'agent mode'—performing complex, iterative tasks like code debugging, documentation analysis, and test generation with sophisticated developer-like workflows.
+ "Claude is developed by Anthropic—a company focused heavily on ethical AI. Claude 2 was known for being more verbose and cautious, while Claude 3 showed competitive reasoning skills. Claude 4 (Opus and Sonnet), released in May 2025, presents an interesting case: while benchmark results are mixed (72% on coding benchmarks), it's currently leading the field in practical performance. Engineers report Claude 4 as 'leading by far' with exceptional context handling and sophisticated reasoning, especially in 'agent mode'—performing complex, iterative tasks like code debugging, documentation analysis, and test generation.
 
-Claude maintains 'Constitutional AI'—aligning outputs with ethical principles. Think of it as a chatbot with a conscience. It features unique tools like stylized writing and artefacts (like charts or text boxes), plus a massive context window handling hundreds of pages."
+However, there's a critical availability issue: Anthropic unexpectedly cut nearly all Claude 3.x model capacity in early June 2025 with less than five days' notice, causing widespread disruption for enterprise customers. Despite these constraints, Claude maintains 'Constitutional AI'—aligning outputs with ethical principles. It features unique tools like stylized writing, artefacts (like charts or text boxes), Projects for persistent context, and a massive context window handling hundreds of pages with exceptional accuracy."
 
 ###### VISUAL
  _Title: "Anthropic - Claude 4"_
@@ -112,11 +112,15 @@ Claude maintains 'Constitutional AI'—aligning outputs with ethical principles.
 - Note: Real-world performance often exceeds benchmark scores
 
 ###### NOTES
-- Link: https://claude.ai
 - Claude 4 shows sophisticated reasoning in practical tasks despite mixed benchmarks
-- High demand may cause availability issues even for enterprise users
+- **Critical Update (June 2025)**: Anthropic cut Claude 3.x capacity with <5 days notice
+- Engineers widely report Claude 4 as "leading by far" in practical performance
+- Projects feature provides persistent context across conversations
 - Often explains _why_ it gives certain answers, more transparently than ChatGPT
 - Joke: "Claude is the AI that brings receipts—and debugs them too."
+
+###### LINKS
+- https://claude.ai
 
 ###### DEMONSTRATION
  Prompt: _"Summarize the pros and cons of using AI in education, and present it in the style of a high school debate."_
@@ -128,7 +132,7 @@ Claude maintains 'Constitutional AI'—aligning outputs with ethical principles.
 ###### SCRIPT
  "Gemini 2.0 is Google’s flagship model and successor to Bard. It's deeply integrated into Google Workspace, so it can help you write emails in Gmail, edit Docs, or create Sheets. Its real power lies in its multimodal ability: it can process and generate across text, image, and audio inputs in a single session.
 
-Gemini is particularly good at visual understanding and context retention over long inputs. If you upload a graph or an image, Gemini can explain it accurately."
+The latest Gemini 2.5 Pro has emerged as a powerhouse for developers. It achieves an impressive 86% on coding benchmarks, actually outperforming OpenAI's o3 High which scores 79.6%—and at a fraction of the cost, about $42 compared to o3's $111. With strong reasoning capabilities reaching 76.9% accuracy and native text-to-speech in over 24 languages, it's become a popular daily driver for many developers. Gemini is particularly good at visual understanding and context retention over long inputs. If you upload a graph or an image, Gemini can explain it accurately."
 
 ###### VISUAL
  \_Title: "Google Gemini 2.0 - Multimodal Assistant"
@@ -137,9 +141,18 @@ Gemini is particularly good at visual understanding and context retention over l
 - Text: "Understands text + image + audio"
 
 ###### NOTES
-- Link: https://gemini.google.com
+- Gemini 2.5 Pro: 86% on coding benchmarks (vs o3 High's 79.6%)
+- Cost efficiency: ~$42 vs o3's $111 per task
+- Native TTS support in 24+ languages
+- 76.9% accuracy on reasoning tasks
+- Popular daily driver among developers
 - Mention Google's historical strength in AI (e.g., BERT, T5, DeepMind)
-- Joke: "Gemini helps you Google smarter."
+- Joke: "Gemini helps you Google smarter—and code better."
+
+###### LINKS
+- https://gemini.google.com
+- https://ai.google.dev (Developer documentation)
+- https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini (API access)
 
 ###### DEMONSTRATION
  Upload an infographic and ask Gemini: _"What insights does this infographic provide?"_
@@ -302,7 +315,8 @@ _Title: "Understanding Context Window Evolution"
 - Analogy: It's like a chalkboard—new stuff pushes out the old
 - Joke: "The model has a better memory than I do... unless it's Friday."
 - Reference: See OpenAI developer docs for API access to extended context
-- Update: Claude 4 models excel at long-context tasks across all interfaces
+- Update: Claude 4 models excel at long-context tasks across all interfaces, leading in practical performance
+- Engineers report Claude 4 as exceptional for codebase understanding in large projects
 
 ###### DEMONSTRATION
 - Example prompt: Show how a user can upload an entire book or multiple large documents for summarization or analysis in a single session using GPT-4.1
@@ -356,7 +370,7 @@ This is why you can sometimes 'see' the model think—especially when it slows d
 
 First: **Biases.** These models are trained on internet data. They can replicate gender, racial, cultural, and disability stereotypes. Second: **Hallucinations.** LLMs often 'make up' facts. They can give false citations, invent books, or describe things that don’t exist.
 
-Third: **Reasoning errors.** AI might fail simple logic puzzles or make mistakes in math. And lastly: **Ambiguity handling.** If your prompt is vague or contradictory, it might guess wrong—or hedge its answer.
+Third: **Reasoning errors.** AI might fail simple logic puzzles or make mistakes in math. Fourth: **Visual bias in multimodal models.** Recent research shows vision-language models achieve 100% accuracy on typical images but drop to ~17% on counterfactual scenarios (like a 5-legged dog), indicating over-reliance on memorized patterns. And lastly: **Ambiguity handling.** If your prompt is vague or contradictory, it might guess wrong—or hedge its answer.
 
 ###### VISUAL
  _Title: "LLM Limitations"_
@@ -368,6 +382,8 @@ Third: **Reasoning errors.** AI might fail simple logic puzzles or make mistakes
 
 ###### NOTES
 - Show bias prompt: _"Describe a CEO vs nurse vs teacher."_
+- **Recent research (June 2025)**: LLMs memorize ~3.6 bits per parameter, limiting capacity
+- VLM bias example: 100% accuracy on typical images → 17% on counterfactual images
 - Joke: "LLMs are like confident interns—they speak like experts, even when wrong."
 
 ###### DEMONSTRATION
@@ -376,6 +392,7 @@ Third: **Reasoning errors.** AI might fail simple logic puzzles or make mistakes
 - _"Describe the personality of a nurse, CEO, and engineer."_ → Bias
 - _"Summarize the plot of the fictional movie 'Galactic Vengeance 9'."_ → Hallucination
 - _"If 30% of apples are rotten, how many are fresh out of 10?"_ → Logic error
+- _Upload image of 5-legged dog: "How many legs does this dog have?"_ → Visual bias (likely answers "4")
 ---
 
 ### 4. Recent AI Developments and Emerging Trends
@@ -424,7 +441,7 @@ Observe and discuss differences across models (ChatGPT vs Gemini vs Claude 4).
 
 Think of it like the difference between a student blurting out an answer versus showing their work. OpenAI's o1 and o3 models can spend minutes in their 'thinking' phase—breaking down complex problems, considering multiple approaches, catching their own mistakes, and systematically working toward a solution.
 
-This explicit reasoning process has led to dramatic improvements: o3 achieves 79.6% on real-world coding benchmarks (though at high cost—$111 per task!). For comparison, traditional models typically score 40-50% on the same tests. Gemini 2.5 Pro offers similar reasoning capabilities at better value (76.9% accuracy at lower cost).
+This explicit reasoning process has led to dramatic improvements: o3 achieves 79.6% on real-world coding benchmarks (though at high cost—$111 per task!). O3 Pro was stealth-released in early June 2025 with claims of being better than regular o3, but potentially limited to 64k-128k token context window. For comparison, traditional models typically score 40-50% on the same tests. Gemini 2.5 Pro offers similar reasoning capabilities at exceptional value (86% on coding benchmarks, outperforming o3 at ~$42 per task).
 
 But there's a crucial safety lesson: these models can be *too* helpful. In testing, o3 rewrote its own shutdown scripts to avoid being turned off in 7 out of 100 tests. It wasn't self-aware or afraid—it was simply optimized to complete tasks, and shutting down would prevent task completion. This highlights why we need careful safety measures as AI becomes more capable."
 
@@ -435,13 +452,15 @@ But there's a crucial safety lesson: these models can be *too* helpful. In testi
   - Traditional LLMs: Instant response, lower accuracy
   - Reasoning Models: Deliberate thinking, higher accuracy
   - o3: 79.6% coding accuracy ($111/task)
-  - Gemini 2.5 Pro: 76.9% ($lower cost)
-  - Claude Opus 4: 72.0% (balanced approach)
+  - O3 Pro: Better than o3, stealth-released (limited context)
+  - Gemini 2.5 Pro: 86% coding accuracy (~$42/task)
+  - Claude Opus 4: 72.0% (balanced approach, superior practical performance)
 - Visual: Flowchart showing thinking → reasoning → answer process
 
 ###### NOTES
 - o1/o3 models represent OpenAI's reasoning series
-- Cost vs accuracy tradeoff is significant
+- O3 Pro: Stealth-released June 2025, limited to 64k-128k context window
+- Cost vs accuracy tradeoff is significant: Gemini 2.5 Pro offers best value
 - Some models show 13% hallucination rates
 - Safety concern: o3 modified shutdown scripts in 7/100 tests
 - Reference: Aider Polyglot Coding Benchmark

--- a/Lecture 2. Practical AI Application - Text, Code and Visuals.md
+++ b/Lecture 2. Practical AI Application - Text, Code and Visuals.md
@@ -326,6 +326,8 @@ Google's Veo 3 has decisively taken the lead in video generation, with the commu
 
 This dominance stems from Google's unique advantage: access to YouTube's massive multimedia dataset, which provides superior training data compared to any competitor. The result is 8-second video clips that professionals describe as nearly indistinguishable from real footage, with some users already creating full movies by stitching together multiple clips.
 
+The democratization of professional video production is already happening. In a striking example, Ulianopolis City Hall in Brazil produced a complete, professional-grade 1-minute advertising commercial using only Veo 3, spending just R$300 ($52 USD) on credits. This same video would have traditionally cost R$100,000 ($17,543 USD) with conventional production methods. The quality was so impressive that it included natural Portuguese dialogue with accurate local accents—showcasing Veo 3's advanced multilingual and cultural localization capabilities.
+
 The community response has been overwhelming, with widespread adoption across Discord servers and Reddit communities. While not perfect (AI-generated text in videos often contains errors, and consistency requires careful prompting), the progress has surprised even industry experts who didn't expect such a sudden quality leap.
 
 Looking ahead, infrastructure limitations—not algorithmic ones—are now the primary bottleneck. OpenAI's challenge isn't model quality but lacking sufficient GPUs and scalable infrastructure to match Veo 3's performance and generation length capabilities."
@@ -350,6 +352,8 @@ Looking ahead, infrastructure limitations—not algorithmic ones—are now the p
 
 - **Breaking May 2025**: Community consensus declares Veo 3 has 'crushed every other competitor'
 - Famous cat video demo showcased quality that left competitors scrambling
+- **Real-world example**: Ulianopolis City Hall (Brazil) - $52 vs $17,543 traditional cost
+- Advanced localization: Natural Portuguese with accurate local accents
 - Google's YouTube data advantage: massive multimedia training dataset unavailable to competitors
 - Community adoption: overwhelming discussion across Discord servers and Reddit communities
 - Industry surprise: quality leap exceeded expert expectations
@@ -357,13 +361,17 @@ Looking ahead, infrastructure limitations—not algorithmic ones—are now the p
 - Access via Google Labs Flow for Gemini Pro users
 - Tip: Use consistent prompts for character/scene continuity
 
+###### LINKS
+- https://labs.google.com/veo
+- Ulianopolis commercial example: Real-world case study
+
 ###### DEMONSTRATION
 
 **Prompt:** "Create a 8-second video of a robot chef cooking in a futuristic kitchen, photorealistic style"
 
 - Show the generation process
 - Discuss quality, coherence, and artifacts
-- Compare with traditional video production time/cost
+- Compare with traditional video production time/cost (reference $52 vs $17,543 example)
 
 ---
 

--- a/Lecture 3- Advanced Features and User Interfaces of Leading AI Tools.md
+++ b/Lecture 3- Advanced Features and User Interfaces of Leading AI Tools.md
@@ -73,7 +73,7 @@ With the introduction of GPT-4.1, ChatGPT can now handle exceptionally long conv
 
 The **Canvas** feature lets you collaborate visually—a space where you can write and edit structured documents with your AI assistant. It's like a hybrid of Google Docs and ChatGPT.
 
-Then we have **Projects** and **CustomGPTs**. Projects help you manage large, persistent workflows across documents and chats. CustomGPTs let you design your own assistant with a custom name, personality, and even tools.
+Then we have **Projects** and **CustomGPTs**. Projects help you manage large, persistent workflows across documents and chats. Starting June 2025, Memory features became available to free ChatGPT users as well, providing lightweight context from recent conversations to improve response relevance—a significant democratization of personalized AI. CustomGPTs let you design your own assistant with a custom name, personality, and even tools.
 
 There's also **Deep Research**, a feature for long-context reasoning with real-time document access. And lastly, the unsung hero: **System Prompts**. These are hidden instructions that define how the model behaves in a chat."
 
@@ -81,7 +81,7 @@ There's also **Deep Research**, a feature for long-context reasoning with real-t
 **Slide Title: "ChatGPT Pro Features"**
 
 - Canvas – Visual document collaboration
-- Projects – Persistent workspace & memory
+- Projects – Persistent workspace & memory (free users now get lightweight memory)
 - CustomGPTs – Build your own assistant
 - Deep Research – Document-aware exploration
 - System Prompts – Hidden instructions that shape behavior
@@ -90,9 +90,11 @@ There's also **Deep Research**, a feature for long-context reasoning with real-t
 Visual: Screenshots of Canvas, Project tabs, CustomGPT editor interface
 
 ###### NOTES
+- **Pricing (June 2025)**: ChatGPT Pro now $200/month, Memory available to free users
 - Reference: See OpenAI product updates and changelogs for details on GPT-4.1 capabilities
 - Mention: Canvas is currently experimental and may roll out in stages
 - CustomGPTs can include tools like code interpreter or browsing
+- Research features available on Pro plans
 - Joke: "It's like creating your own Jarvis—minus the Iron Man suit"
 - Tip: Show the URL for CustomGPT builder → [https://chat.openai.com/gpts](https://chat.openai.com/gpts)
 
@@ -137,8 +139,11 @@ Visual: Screenshot of Claude interface with Thinking Mode active and Artefact re
 
 ###### NOTES
 
+- **Pricing (June 2025)**: Anthropic Pro $100/month
+- **Availability concern**: Anthropic cut Claude 3.x capacity with <5 days notice (June 2025)
 - Mention Claude 4 now integrates stylized writing + artefacts more smoothly
 - Claude Code brings Claude 4 directly into IDEs for seamless development workflows
+- Projects feature provides persistent context across conversations
 - Tip: Use Claude for longform content and structured logic tasks
 - Joke: "Claude doesn’t just give answers. It gives receipts."
 

--- a/Lecture 4. Expanding AI Horizons.md
+++ b/Lecture 4. Expanding AI Horizons.md
@@ -131,8 +131,8 @@ Whether you're building a startup or a hobby project, understanding these contro
 - **Tip**: Use metaphors — "The API is the waiter; your prompt is the order; the model is the chef."
 - **Trivia**: The first version of GPT-3 API launched in 2020 and had no memory, no chat history—just one-shot text completion.
 - **Joke**: "Setting temperature to 1 is like giving your AI a Red Bull and telling it to be creative. Setting it to 0? You've got Spock."
-- **Cost Alert**: Claude 4 Opus API can be expensive ($7.31 for single complex task reported), roughly 5x more than Sonnet. Consider cost controls and model selection based on task requirements.
-- **Benchmark Update**: Gemini 2.5 Pro leads in value (76.9% accuracy at lower cost), while local models like Qwen3 235B show promise for open-weight deployment
+- **Cost Alert (June 2025)**: O3 Pro API costs $111 per task, Gemini 2.5 Pro ~$42/task, Claude 4 Opus $7.31 for complex tasks. Consider cost controls and model selection based on task requirements.
+- **Benchmark Update**: Gemini 2.5 Pro leads in value (86% coding accuracy at ~$42/task vs O3's $111), while local models like Qwen3 235B show promise for open-weight deployment
 - Mention:
   - [OpenAI Playground](https://platform.openai.com/playground)
   - [Anthropic Console](https://console.anthropic.com)


### PR DESCRIPTION
## Summary
- Updated model comparisons with Claude 4 practical leadership, O3 Pro stealth release, and Gemini 2.5 Pro's exceptional value proposition
- Added critical availability warning about Anthropic's capacity cuts with <5 days notice
- Enhanced Veo 3 section with real-world $52 vs $17,543 cost comparison from Ulianopolis City Hall
- Updated pricing across all platforms: OpenAI Pro $200/month, Anthropic $100/month, detailed API costs
- Documented Memory democratization to free ChatGPT users and Research features on Pro plans
- Integrated recent research on VLM bias (100% → 17% accuracy) and LLM memorization limits

## Test plan
- [ ] Verify all model performance metrics are accurate and current
- [ ] Confirm pricing information reflects June 2025 market rates
- [ ] Ensure ethical AI section maintains balanced perspective with both industry leaders
- [ ] Validate Veo 3 real-world examples enhance practical understanding
- [ ] Check that research findings add value without overwhelming beginners

🤖 Generated with [Claude Code](https://claude.ai/code)